### PR TITLE
Fix rendering of embeds where page title has &

### DIFF
--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -23,7 +23,7 @@ const Op = _Op;
  * @return The processed link.
  */
 function fixRenderingForEmbed(link) {
-  let newLink = link.replace(/&/g, "%26");
+  let newLink = link.replace(/&/g, encodeURIComponent);
   return newLink;
 }
 

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -23,8 +23,7 @@ const Op = _Op;
  * @return The processed link.
  */
 function fixRenderingForEmbed(link) {
-  let newLink = link.replace(/&/g, encodeURIComponent);
-  return newLink;
+  return link.replace(/&/g, encodeURIComponent);
 }
 
 export const name = Events.MessageCreate;

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -11,6 +11,22 @@ import { Blacklist, ModLogs } from "../includes/index.js";
 
 const Op = _Op;
 
+/**
+ * This function replaces the character `&` into its URL-escaped form.
+ * 
+ * This function is used to fix rendering of embeds when the page title contains special characters
+ * like `&`, which may not be handled by Discord as expected. This function does not simply replace
+ * all reserved characters, which can make the link look uglier when those are replaced.
+ * 
+ * @author C-Ezra-M
+ * @param {string} link The link to process.
+ * @return The processed link.
+ */
+function fixRenderingForEmbed(link) {
+  let newLink = link.replace(/&/g, "%26");
+  return newLink;
+}
+
 export const name = Events.MessageCreate;
 export async function execute(message) {
   if (message.guild.id !== config.guildID || !message.member) return;
@@ -28,7 +44,7 @@ export async function execute(message) {
       if (response.statusCode === 200) {
         let data = response.body;
         if (data[3] && data[3].length > 0) {
-          const firstLink = data[3][0];
+          const firstLink = fixRenderingForEmbed(data[3][0]);
           return message.reply(firstLink);
         } else {
           return message.reply(


### PR DESCRIPTION
Discord takes `&` as a URL param separator (even if it's not after `?`), so `Scarlet_&_Violet_(TCG)` is clipped to `Scarlet_` and normalized to `Scarlet`
![image](https://github.com/user-attachments/assets/fc3d9b22-b48a-4ee3-9dd0-7f1f6ef7c78f)
